### PR TITLE
Fixes to locales en and de

### DIFF
--- a/packages/frontend/locales/de.json
+++ b/packages/frontend/locales/de.json
@@ -1,10 +1,10 @@
 {
 	"common": {
-		"note": "Hinweis",
+		"note": "Notiz",
 		"file": "Datei",
 		"advanced": "erweitert",
 		"create": "erstellen",
-		"loading": "läd",
+		"loading": "lädt",
 		"mode": "Modus",
 		"views": "{n, plural, =0 {Ansichten} =1 {1 Ansicht} other {# Ansichten}}",
 		"minutes": "{n, plural, =0 {Minuten} =1 {1 Minute} other {# Minuten}}",
@@ -12,7 +12,7 @@
 		"share_link": "Link teilen",
 		"copy_clipboard": "in die Zwischenablage kopieren",
 		"copied_to_clipboard": "in die Zwischenablage kopiert",
-		"encrypting": "verschlüsseln",
+		"encrypting": "verschlüsselt",
 		"decrypting": "entschlüsselt",
 		"uploading": "hochladen",
 		"downloading": "wird heruntergeladen",
@@ -22,7 +22,7 @@
 	"home": {
 		"intro": "Senden Sie ganz einfach <i>vollständig verschlüsselte</i>, sichere Notizen oder Dateien mit einem Klick. Erstellen Sie einfach eine Notiz und teilen Sie den Link.",
 		"explanation": "die Notiz verfällt und wird nach {type} zerstört.",
-		"new_note": "neue Note",
+		"new_note": "neue Notiz",
 		"new_note_notice": "<b>Verfügbarkeit:</b><br />es ist nicht garantiert, dass die Notiz gespeichert wird, da alles im Speicher gehalten wird. Wenn dieser voll ist, werden die ältesten Notizen entfernt.<br />(Sie werden wahrscheinlich keine Probleme haben, seien Sie nur gewarnt).",
 		"errors": {
 			"note_to_big": "Notiz konnte nicht erstellt werden. Notiz ist zu groß",
@@ -41,12 +41,12 @@
 	"show": {
 		"errors": {
 			"not_found": "wurde nicht gefunden oder wurde bereits gelöscht.",
-			"decryption_failed": "falsches Passwort. konnte nicht entziffert werden. wahrscheinlich ein defekter Link. Notiz wurde zerstört.",
+			"decryption_failed": "falsches Passwort. konnte nicht entschlüsselt werden. wahrscheinlich ein defekter Link. Notiz wurde zerstört.",
 			"unsupported_type": "nicht unterstützter Notiztyp."
 		},
 		"explanation": "Klicken Sie unten, um die Notiz anzuzeigen und zu löschen, wenn der Zähler sein Limit erreicht hat",
 		"show_note": "Notiz anzeigen",
-		"warning_will_not_see_again": "haben Sie <b>keine</b> Gelegenheit, die Notiz noch einmal zu sehen.",
+		"warning_will_not_see_again": "Sie haben <b>keine</b> Gelegenheit, die Notiz noch einmal zu sehen.",
 		"download_all": "alle herunterladen",
 		"links_found": "Links in der Notiz:"
 	},

--- a/packages/frontend/locales/en.json
+++ b/packages/frontend/locales/en.json
@@ -25,7 +25,7 @@
 		"new_note": "new note",
 		"new_note_notice": "<b>availability:</b><br />the note is not guaranteed to be stored as everything is kept in ram, if it fills up the oldest notes will be removed.<br />(you probably will be fine, just be warned.)",
 		"errors": {
-			"note_to_big": "could not create note. note is to big",
+			"note_to_big": "could not create note. note is too big",
 			"note_error": "could not create note. please try again.",
 			"max": "max: {n}",
 			"empty_content": "note is empty."
@@ -44,7 +44,7 @@
 			"decryption_failed": "wrong password. could not decipher. probably a broken link. note was destroyed.",
 			"unsupported_type": "unsupported note type."
 		},
-		"explanation": "click below to show and delete the note if the counter has reached it's limit",
+		"explanation": "click below to show and delete the note if the counter has reached its limit",
 		"show_note": "show note",
 		"warning_will_not_see_again": "you will <b>not</b> get the chance to see the note again.",
 		"download_all": "download all",


### PR DESCRIPTION
Version 2.4.0 unfortunately changed two string in "en" locale from the correct spelling to the wrong spelling. This PR fixes these, as well as some translation errors in the "de" locale.