### PR TITLE
fix key for home.new_note_notice

### DIFF
--- a/packages/frontend/src/lib/ui/NoteResult.svelte
+++ b/packages/frontend/src/lib/ui/NoteResult.svelte
@@ -37,7 +37,7 @@
 
 {#if $status?.theme_new_note_notice}
 	<p>
-		{@html $t('home.theme_new_note_notice')}
+		{@html $t('home.new_note_notice')}
 	</p>
 {/if}
 <br />


### PR DESCRIPTION
In translations there is a key `home.new_note_notice` but in template it's used as `home.theme_new_note_notice`. This fixes missing translation.