### PR TITLE
Add redis tls feature 'rediss://'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,13 +15,13 @@ FROM rust:1.76-alpine as backend
 WORKDIR /tmp
 RUN apk add --no-cache libc-dev openssl-dev alpine-sdk
 COPY ./packages/backend ./
-RUN cargo build --release
+RUN RUSTFLAGS="-Ctarget-feature=-crt-static" cargo build --release
 
 
 # RUNNER
 FROM alpine:3.19
 WORKDIR /app
-RUN apk add --no-cache curl 
+RUN apk add --no-cache curl libgcc
 COPY --from=backend /tmp/target/release/cryptgeon .
 COPY --from=client /tmp/packages/frontend/build ./frontend
 ENV FRONTEND_PATH="./frontend"

--- a/packages/backend/Cargo.toml
+++ b/packages/backend/Cargo.toml
@@ -22,4 +22,4 @@ dotenv = "0.15"
 mime = "0.3"
 env_logger = "0.9"
 log = "0.4"
-redis = "0.23"
+redis = { version = "0.25.2", features = ["tls-native-tls"] }

--- a/packages/backend/src/store.rs
+++ b/packages/backend/src/store.rs
@@ -36,7 +36,7 @@ pub fn set(id: &String, note: &Note) -> Result<(), &'static str> {
     match note.expiration {
         Some(e) => {
             let seconds = e - now();
-            conn.expire(id, seconds as usize)
+            conn.expire(id, seconds as i64)
                 .map_err(|_| "Unable to set expiration on notion")?
         }
         None => {}


### PR DESCRIPTION
Update to redis crate 0.25.2 with TLS support

This should fix https://github.com/cupcakearmy/cryptgeon/issues/121

Tested OK on Azure Cache for Redis