### PR TITLE
Added an Imprint button redirecting to a given URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ of the notes even if it tried to.
 | `THEME_PAGE_TITLE`      | `""`             | Custom text the page title                                                                                                                                                                                    |
 | `THEME_FAVICON`         | `""`             | Custom url for the favicon. Must be publicly reachable                                                                                                                                                        |
 | `THEME_NEW_NOTE_NOTICE` | `true`           | Show the message about how notes are stored in the memory and may be evicted after creating a new note. Defaults to `true`.                                                                                   |
+| `IMPRINT_URL`           | `""`             | Custom url for an Imprint hosted somewhere else. Must be publicly reachable.                                                                                                                                  |
 
 ## Deployment
 

--- a/packages/backend/src/config.rs
+++ b/packages/backend/src/config.rs
@@ -38,6 +38,10 @@ pub static ref ALLOW_FILES: bool = std::env::var("ALLOW_FILES")
   .unwrap_or("true".to_string())
   .parse()
   .unwrap();
+pub static ref IMPRINT_URL: String = std::env::var("IMPRINT_URL")
+  .unwrap_or("".to_string())
+  .parse()
+  .unwrap();
 }
 
 // THEME

--- a/packages/backend/src/status/mod.rs
+++ b/packages/backend/src/status/mod.rs
@@ -12,6 +12,7 @@ pub struct Status {
     pub max_expiration: u32,
     pub allow_advanced: bool,
     pub allow_files: bool,
+    pub imprint_url: String,
     // Theme
     pub theme_image: String,
     pub theme_text: String,
@@ -28,6 +29,7 @@ pub async fn get_status() -> (StatusCode, Json<Status>) {
         max_expiration: *config::MAX_EXPIRATION,
         allow_advanced: *config::ALLOW_ADVANCED,
         allow_files: *config::ALLOW_FILES,
+        imprint_url: config::IMPRINT_URL.to_string(),
         theme_new_note_notice: *config::THEME_NEW_NOTE_NOTICE,
         theme_image: config::THEME_IMAGE.to_string(),
         theme_text: config::THEME_TEXT.to_string(),

--- a/packages/cli/src/shared/api.ts
+++ b/packages/cli/src/shared/api.ts
@@ -113,6 +113,7 @@ export type Status = {
   max_expiration: number
   allow_advanced: boolean
   allow_files: boolean
+  imprint_url: string
   theme_image: string
   theme_text: string
   theme_favicon: string

--- a/packages/frontend/src/lib/views/Footer.svelte
+++ b/packages/frontend/src/lib/views/Footer.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import ThemeToggle from '$lib/ui/ThemeToggle.svelte'
+        import { status } from '$lib/stores/status'
 </script>
 
 <footer>
@@ -7,6 +8,9 @@
 	<nav>
 		<a href="/">/home</a>
 		<a href="/about">/about</a>
+		{#if $status?.imprint_url}
+			<a href={$status.imprint_url} target="_blank" rel="noopener noreferrer">/imprint</a>
+		{/if}
 		<a href="https://github.com/cupcakearmy/cryptgeon" target="_blank" rel="noopener noreferrer">
 			code
 		</a>


### PR DESCRIPTION
Hi,

thank you for your great work! I'll try to avoid jurisdiction as much as possible, but long story short, if you are providing a service in germany that is not strictly targeted to family and friends you need to provide an imprint.

Hence I've added a simple option to provide an URL using the environment variable `IMPRINT_URL`. If the env var is provided, an imprint button shows up. If not, then the button doesn't show.
![image](https://github.com/user-attachments/assets/b960a64f-4ffe-42de-bc6f-af3af36f1acf)

best wishes,
Uli
