### PR TITLE
Added Option to set a custom HTML Imprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ of the notes even if it tried to.
 | `THEME_PAGE_TITLE`      | `""`             | Custom text the page title                                                                                                                                                                                    |
 | `THEME_FAVICON`         | `""`             | Custom url for the favicon. Must be publicly reachable                                                                                                                                                        |
 | `THEME_NEW_NOTE_NOTICE` | `true`           | Show the message about how notes are stored in the memory and may be evicted after creating a new note. Defaults to `true`.                                                                                   |
+| `IMPRINT_URL`           | `""`             | Custom url for an Imprint hosted somewhere else. Must be publicly reachable.                                                                                                                                  |
 
 ## Deployment
 

--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ of the notes even if it tried to.
 | `THEME_PAGE_TITLE`      | `""`             | Custom text the page title                                                                                                                                                                                    |
 | `THEME_FAVICON`         | `""`             | Custom url for the favicon. Must be publicly reachable                                                                                                                                                        |
 | `THEME_NEW_NOTE_NOTICE` | `true`           | Show the message about how notes are stored in the memory and may be evicted after creating a new note. Defaults to `true`.                                                                                   |
-| `IMPRINT_URL`           | `""`             | Custom url for an Imprint hosted somewhere else. Must be publicly reachable.                                                                                                                                  |
-
+| `IMPRINT_URL`           | `""`             | Custom url for an Imprint hosted somewhere else. Must be publicly reachable. Takes precedence above `IMPRINT_HTML`.                                                                                                       |
+| `IMPRINT_HTML`          | `""`             | Alternative to `IMPRINT_URL`, this can be used to specify the HTML code to show on `/imprint`. Only `IMPRINT_HTML` or `IMPRINT_URL` should be specified, not both.|
 ## Deployment
 
 > ℹ️ `https` is required otherwise browsers will not support the cryptographic functions.

--- a/packages/backend/src/config.rs
+++ b/packages/backend/src/config.rs
@@ -38,6 +38,10 @@ pub static ref ALLOW_FILES: bool = std::env::var("ALLOW_FILES")
   .unwrap_or("true".to_string())
   .parse()
   .unwrap();
+pub static ref IMPRINT_URL: String = std::env::var("IMPRINT_URL")
+  .unwrap_or("".to_string())
+  .parse()
+  .unwrap();
 }
 
 // THEME

--- a/packages/backend/src/config.rs
+++ b/packages/backend/src/config.rs
@@ -42,6 +42,10 @@ pub static ref IMPRINT_URL: String = std::env::var("IMPRINT_URL")
   .unwrap_or("".to_string())
   .parse()
   .unwrap();
+pub static ref IMPRINT_HTML: String = std::env::var("IMPRINT_HTML")
+  .unwrap_or("".to_string())
+  .parse()
+  .unwrap();
 }
 
 // THEME

--- a/packages/backend/src/status/mod.rs
+++ b/packages/backend/src/status/mod.rs
@@ -13,6 +13,7 @@ pub struct Status {
     pub allow_advanced: bool,
     pub allow_files: bool,
     pub imprint_url: String,
+    pub imprint_html: String,
     // Theme
     pub theme_image: String,
     pub theme_text: String,
@@ -30,6 +31,7 @@ pub async fn get_status() -> (StatusCode, Json<Status>) {
         allow_advanced: *config::ALLOW_ADVANCED,
         allow_files: *config::ALLOW_FILES,
         imprint_url: config::IMPRINT_URL.to_string(),
+        imprint_html: config::IMPRINT_HTML.to_string(),
         theme_new_note_notice: *config::THEME_NEW_NOTE_NOTICE,
         theme_image: config::THEME_IMAGE.to_string(),
         theme_text: config::THEME_TEXT.to_string(),

--- a/packages/backend/src/status/mod.rs
+++ b/packages/backend/src/status/mod.rs
@@ -12,6 +12,7 @@ pub struct Status {
     pub max_expiration: u32,
     pub allow_advanced: bool,
     pub allow_files: bool,
+    pub imprint_url: String,
     // Theme
     pub theme_image: String,
     pub theme_text: String,
@@ -28,6 +29,7 @@ pub async fn get_status() -> (StatusCode, Json<Status>) {
         max_expiration: *config::MAX_EXPIRATION,
         allow_advanced: *config::ALLOW_ADVANCED,
         allow_files: *config::ALLOW_FILES,
+        imprint_url: config::IMPRINT_URL.to_string(),
         theme_new_note_notice: *config::THEME_NEW_NOTE_NOTICE,
         theme_image: config::THEME_IMAGE.to_string(),
         theme_text: config::THEME_TEXT.to_string(),

--- a/packages/cli/src/shared/api.ts
+++ b/packages/cli/src/shared/api.ts
@@ -113,6 +113,7 @@ export type Status = {
   max_expiration: number
   allow_advanced: boolean
   allow_files: boolean
+  imprint_url: string
   theme_image: string
   theme_text: string
   theme_favicon: string

--- a/packages/cli/src/shared/api.ts
+++ b/packages/cli/src/shared/api.ts
@@ -114,6 +114,7 @@ export type Status = {
   allow_advanced: boolean
   allow_files: boolean
   imprint_url: string
+  imprint_html: string
   theme_image: string
   theme_text: string
   theme_favicon: string

--- a/packages/frontend/src/lib/views/Footer.svelte
+++ b/packages/frontend/src/lib/views/Footer.svelte
@@ -10,6 +10,8 @@
 		<a href="/about">/about</a>
 		{#if $status?.imprint_url}
 			<a href={$status.imprint_url} target="_blank" rel="noopener noreferrer">/imprint</a>
+		{:else if $status?.imprint_html}
+			<a href="/imprint">/imprint</a>
 		{/if}
 		<a href="https://github.com/cupcakearmy/cryptgeon" target="_blank" rel="noopener noreferrer">
 			code

--- a/packages/frontend/src/lib/views/Footer.svelte
+++ b/packages/frontend/src/lib/views/Footer.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import ThemeToggle from '$lib/ui/ThemeToggle.svelte'
+        import { status } from '$lib/stores/status'
 </script>
 
 <footer>
@@ -7,6 +8,9 @@
 	<nav>
 		<a href="/">/home</a>
 		<a href="/about">/about</a>
+		{#if $status?.imprint_url}
+			<a href={$status.imprint_url} target="_blank" rel="noopener noreferrer">/imprint</a>
+		{/if}
 		<a href="https://github.com/cupcakearmy/cryptgeon" target="_blank" rel="noopener noreferrer">
 			code
 		</a>

--- a/packages/frontend/src/routes/imprint/+page.svelte
+++ b/packages/frontend/src/routes/imprint/+page.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+	import { get } from 'svelte/store';
+	import { goto } from '$app/navigation';
+	import { status } from '$lib/stores/status'
+	
+	status.subscribe((config) => {
+		if (config != null) {
+			if (config.imprint_url) {
+				window.location = config.imprint_url;
+			}
+			else if (config.imprint_html == "") {
+				goto("/about");
+			}
+		}
+	});
+</script>
+
+<svelte:head>
+	<title>Imprint</title>
+</svelte:head>
+
+<section class="content">
+{#if $status?.imprint_html}
+	{@html $status.imprint_html}
+{/if}
+</section>
+
+<style>
+	section {
+		width: 100%;
+		display: flex;
+		flex-direction: column;
+		gap: 2rem;
+	}
+</style>


### PR DESCRIPTION
Hi,

related to https://github.com/cupcakearmy/cryptgeon/pull/152, but a little more sophisticated. Additionally to just simply set an external URL this would allow to also set HTML code via the Enviroment variable `IMPRINT_HTML`.

This has the drawback that a route to `/imprint` is needed, regardless whether the Imprint feature is used or not. As of now the `/imprint` route just redirects to `/about` if nothing is configured.

If `IMPRINT_URL` is specified it takes precedence and `/imprint` redirects to the given URL. Only if `IMPRINT_HTML` is given, it'll show on `/imprint`.

The result looks something like this (depending on the given HTML):
![sample](https://github.com/user-attachments/assets/ab9347ec-1317-4633-9ced-694bcd94a767)

