### PR TITLE
docs(compose): prevent anonymous volume creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ of the notes even if it tried to.
 | `THEME_PAGE_TITLE`      | `""`             | Custom text the page title                                                                                                                                                                                    |
 | `THEME_FAVICON`         | `""`             | Custom url for the favicon. Must be publicly reachable                                                                                                                                                        |
 | `THEME_NEW_NOTE_NOTICE` | `true`           | Show the message about how notes are stored in the memory and may be evicted after creating a new note. Defaults to `true`.                                                                                   |
-| `IMPRINT_URL`           | `""`             | Custom url for an Imprint hosted somewhere else. Must be publicly reachable. Takes precedence above `IMPRINT_HTML`.                                                                                                       |
-| `IMPRINT_HTML`          | `""`             | Alternative to `IMPRINT_URL`, this can be used to specify the HTML code to show on `/imprint`. Only `IMPRINT_HTML` or `IMPRINT_URL` should be specified, not both.|
+| `IMPRINT_URL`           | `""`             | Custom url for an Imprint hosted somewhere else. Must be publicly reachable. Takes precedence above `IMPRINT_HTML`.                                                                                           |
+| `IMPRINT_HTML`          | `""`             | Alternative to `IMPRINT_URL`, this can be used to specify the HTML code to show on `/imprint`. Only `IMPRINT_HTML` or `IMPRINT_URL` should be specified, not both.                                            |
 ## Deployment
 
 > ℹ️ `https` is required otherwise browsers will not support the cryptographic functions.
@@ -108,9 +108,12 @@ services:
     image: redis:7-alpine
     # This is required to stay in RAM only.
     command: redis-server --save "" --appendonly no
-    # Additionally, you can set a size limit. See link below on how to customise.
-    # https://redis.io/docs/manual/eviction/
-    # --maxmemory 1gb --maxmemory-policy allkeys-lru
+    # Set a size limit. See link below on how to customise.
+    # https://redis.io/docs/latest/operate/rs/databases/memory-performance/eviction-policy/
+    # --maxmemory 1gb --maxmemory-policy allkeys-lrulpine
+    # This prevents the creation of an anonymous volume.
+    tmpfs:
+      - /data
 
   app:
     image: cupcakearmy/cryptgeon:latest

--- a/README_ES.md
+++ b/README_ES.md
@@ -93,9 +93,12 @@ services:
     image: redis:7-alpine
     # This is required to stay in RAM only.
     command: redis-server --save "" --appendonly no
-    # Additionally, you can set a size limit. See link below on how to customise.
-    # https://redis.io/docs/manual/eviction/
-    # --maxmemory 1gb --maxmemory-policy allkeys-lru
+    # Set a size limit. See link below on how to customise.
+    # https://redis.io/docs/latest/operate/rs/databases/memory-performance/eviction-policy/
+    # --maxmemory 1gb --maxmemory-policy allkeys-lrulpine
+    # This prevents the creation of an anonymous volume.
+    tmpfs:
+      - /data
 
   app:
     image: cupcakearmy/cryptgeon:latest

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -74,6 +74,14 @@ version: '3.8'
 services:
   redis:
     image: redis:7-alpine
+    # This is required to stay in RAM only.
+    command: redis-server --save "" --appendonly no
+    # Set a size limit. See link below on how to customise.
+    # https://redis.io/docs/latest/operate/rs/databases/memory-performance/eviction-policy/
+    # --maxmemory 1gb --maxmemory-policy allkeys-lrulpine
+    # This prevents the creation of an anonymous volume.
+    tmpfs:
+      - /data
 
   app:
     image: cupcakearmy/cryptgeon:latest
@@ -110,9 +118,12 @@ services:
     image: redis:7-alpine
     # This is required to stay in RAM only.
     command: redis-server --save "" --appendonly no
-    # Additionally, you can set a size limit. See link below on how to customise.
-    # https://redis.io/docs/manual/eviction/
-    # --maxmemory 1gb --maxmemory-policy allkeys-lru
+    # Set a size limit. See link below on how to customise.
+    # https://redis.io/docs/latest/operate/rs/databases/memory-performance/eviction-policy/
+    # --maxmemory 1gb --maxmemory-policy allkeys-lrulpine
+    # This prevents the creation of an anonymous volume.
+    tmpfs:
+      - /data
 
   app:
     image: cupcakearmy/cryptgeon:latest

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -6,9 +6,12 @@ services:
     image: redis:7-alpine
     # This is required to stay in RAM only.
     command: redis-server --save "" --appendonly no
-    # Additionally, you can set a size limit. See link below on how to customise.
-    # https://redis.io/docs/manual/eviction/
+    # Set a size limit. See link below on how to customise.
+    # https://redis.io/docs/latest/operate/rs/databases/memory-performance/eviction-policy/
     # --maxmemory 1gb --maxmemory-policy allkeys-lrulpine
+    # This prevents the creation of an anonymous volume.
+    tmpfs:
+      - /data
     ports:
       - 6379:6379
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,9 +1,14 @@
 services:
   redis:
     image: redis:7-alpine
+    # This is required to stay in RAM only.
+    command: redis-server --save "" --appendonly no
     # Set a size limit. See link below on how to customise.
     # https://redis.io/docs/latest/operate/rs/databases/memory-performance/eviction-policy/
-    # command: redis-server --maxmemory 1gb --maxmemory-policy allkeys-lru
+    # --maxmemory 1gb --maxmemory-policy allkeys-lrulpine
+    # This prevents the creation of an anonymous volume.
+    tmpfs:
+      - /data
 
   app:
     image: cupcakearmy/cryptgeon:latest

--- a/examples/nginx/docker-compose.yaml
+++ b/examples/nginx/docker-compose.yaml
@@ -5,9 +5,12 @@ services:
     image: redis:7-alpine
     # This is required to stay in RAM only.
     command: redis-server --save "" --appendonly no
-    # Additionally, you can set a size limit. See link below on how to customise.
-    # https://redis.io/docs/manual/eviction/
-    # --maxmemory 1gb --maxmemory-policy allkeys-lru
+    # Set a size limit. See link below on how to customise.
+    # https://redis.io/docs/latest/operate/rs/databases/memory-performance/eviction-policy/
+    # --maxmemory 1gb --maxmemory-policy allkeys-lrulpine
+    # This prevents the creation of an anonymous volume.
+    tmpfs:
+      - /data
 
   app:
     image: cupcakearmy/cryptgeon:latest

--- a/examples/scratch/README.md
+++ b/examples/scratch/README.md
@@ -111,9 +111,12 @@ services:
     image: redis:7-alpine
     # This is required to stay in RAM only.
     command: redis-server --save "" --appendonly no
-    # Additionally, you can set a size limit. See link below on how to customise.
-    # https://redis.io/docs/manual/eviction/
-    # --maxmemory 1gb --maxmemory-policy allkeys-lru
+    # Set a size limit. See link below on how to customise.
+    # https://redis.io/docs/latest/operate/rs/databases/memory-performance/eviction-policy/
+    # --maxmemory 1gb --maxmemory-policy allkeys-lrulpine
+    # This prevents the creation of an anonymous volume.
+    tmpfs:
+      - /data
 
   app:
     image: cupcakearmy/cryptgeon:latest

--- a/examples/traefik/README.md
+++ b/examples/traefik/README.md
@@ -20,9 +20,12 @@ services:
     image: redis:7-alpine
     # This is required to stay in RAM only.
     command: redis-server --save "" --appendonly no
-    # Additionally, you can set a size limit. See link below on how to customise.
-    # https://redis.io/docs/manual/eviction/
-    # --maxmemory 1gb --maxmemory-policy allkeys-lru
+    # Set a size limit. See link below on how to customise.
+    # https://redis.io/docs/latest/operate/rs/databases/memory-performance/eviction-policy/
+    # --maxmemory 1gb --maxmemory-policy allkeys-lrulpine
+    # This prevents the creation of an anonymous volume.
+    tmpfs:
+      - /data
 
   app:
     image: cupcakearmy/cryptgeon:latest
@@ -59,6 +62,14 @@ services:
 
   redis:
     image: redis:7-alpine
+    # This is required to stay in RAM only.
+    command: redis-server --save "" --appendonly no
+    # Set a size limit. See link below on how to customise.
+    # https://redis.io/docs/latest/operate/rs/databases/memory-performance/eviction-policy/
+    # --maxmemory 1gb --maxmemory-policy allkeys-lrulpine
+    # This prevents the creation of an anonymous volume.
+    tmpfs:
+      - /data
 
   cryptgeon:
     image: cupcakearmy/cryptgeon


### PR DESCRIPTION
Addition to https://github.com/cupcakearmy/cryptgeon/issues/176.

The Redis image (https://github.com/redis/docker-library-redis/blob/f00ff0562e52e24f0cde26988628ad7de51fd8d8/7.2/Dockerfile#L113) uses the VOLUME instruction, which creates an anonymous volume when the container is started.

Since we cannot change the base image, our only option is to mount the path via [tmpfs](https://docs.docker.com/engine/storage/tmpfs/). This way no volume is created. (confirmed with `docker volume ls`)