### PR TITLE
Fix maxmemory policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ services:
     command: redis-server --save "" --appendonly no
     # Set a size limit. See link below on how to customise.
     # https://redis.io/docs/latest/operate/rs/databases/memory-performance/eviction-policy/
-    # --maxmemory 1gb --maxmemory-policy allkeys-lrulpine
+    # --maxmemory 1gb --maxmemory-policy allkeys-lru
     # This prevents the creation of an anonymous volume.
     tmpfs:
       - /data

--- a/README_ES.md
+++ b/README_ES.md
@@ -95,7 +95,7 @@ services:
     command: redis-server --save "" --appendonly no
     # Set a size limit. See link below on how to customise.
     # https://redis.io/docs/latest/operate/rs/databases/memory-performance/eviction-policy/
-    # --maxmemory 1gb --maxmemory-policy allkeys-lrulpine
+    # --maxmemory 1gb --maxmemory-policy allkeys-lru
     # This prevents the creation of an anonymous volume.
     tmpfs:
       - /data

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -78,7 +78,7 @@ services:
     command: redis-server --save "" --appendonly no
     # Set a size limit. See link below on how to customise.
     # https://redis.io/docs/latest/operate/rs/databases/memory-performance/eviction-policy/
-    # --maxmemory 1gb --maxmemory-policy allkeys-lrulpine
+    # --maxmemory 1gb --maxmemory-policy allkeys-lru
     # This prevents the creation of an anonymous volume.
     tmpfs:
       - /data
@@ -120,7 +120,7 @@ services:
     command: redis-server --save "" --appendonly no
     # Set a size limit. See link below on how to customise.
     # https://redis.io/docs/latest/operate/rs/databases/memory-performance/eviction-policy/
-    # --maxmemory 1gb --maxmemory-policy allkeys-lrulpine
+    # --maxmemory 1gb --maxmemory-policy allkeys-lru
     # This prevents the creation of an anonymous volume.
     tmpfs:
       - /data

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -8,7 +8,7 @@ services:
     command: redis-server --save "" --appendonly no
     # Set a size limit. See link below on how to customise.
     # https://redis.io/docs/latest/operate/rs/databases/memory-performance/eviction-policy/
-    # --maxmemory 1gb --maxmemory-policy allkeys-lrulpine
+    # --maxmemory 1gb --maxmemory-policy allkeys-lru
     # This prevents the creation of an anonymous volume.
     tmpfs:
       - /data

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,7 +5,7 @@ services:
     command: redis-server --save "" --appendonly no
     # Set a size limit. See link below on how to customise.
     # https://redis.io/docs/latest/operate/rs/databases/memory-performance/eviction-policy/
-    # --maxmemory 1gb --maxmemory-policy allkeys-lrulpine
+    # --maxmemory 1gb --maxmemory-policy allkeys-lru
     # This prevents the creation of an anonymous volume.
     tmpfs:
       - /data

--- a/examples/nginx/docker-compose.yaml
+++ b/examples/nginx/docker-compose.yaml
@@ -7,7 +7,7 @@ services:
     command: redis-server --save "" --appendonly no
     # Set a size limit. See link below on how to customise.
     # https://redis.io/docs/latest/operate/rs/databases/memory-performance/eviction-policy/
-    # --maxmemory 1gb --maxmemory-policy allkeys-lrulpine
+    # --maxmemory 1gb --maxmemory-policy allkeys-lru
     # This prevents the creation of an anonymous volume.
     tmpfs:
       - /data

--- a/examples/scratch/README.md
+++ b/examples/scratch/README.md
@@ -113,7 +113,7 @@ services:
     command: redis-server --save "" --appendonly no
     # Set a size limit. See link below on how to customise.
     # https://redis.io/docs/latest/operate/rs/databases/memory-performance/eviction-policy/
-    # --maxmemory 1gb --maxmemory-policy allkeys-lrulpine
+    # --maxmemory 1gb --maxmemory-policy allkeys-lru
     # This prevents the creation of an anonymous volume.
     tmpfs:
       - /data

--- a/examples/traefik/README.md
+++ b/examples/traefik/README.md
@@ -22,7 +22,7 @@ services:
     command: redis-server --save "" --appendonly no
     # Set a size limit. See link below on how to customise.
     # https://redis.io/docs/latest/operate/rs/databases/memory-performance/eviction-policy/
-    # --maxmemory 1gb --maxmemory-policy allkeys-lrulpine
+    # --maxmemory 1gb --maxmemory-policy allkeys-lru
     # This prevents the creation of an anonymous volume.
     tmpfs:
       - /data
@@ -66,7 +66,7 @@ services:
     command: redis-server --save "" --appendonly no
     # Set a size limit. See link below on how to customise.
     # https://redis.io/docs/latest/operate/rs/databases/memory-performance/eviction-policy/
-    # --maxmemory 1gb --maxmemory-policy allkeys-lrulpine
+    # --maxmemory 1gb --maxmemory-policy allkeys-lru
     # This prevents the creation of an anonymous volume.
     tmpfs:
       - /data


### PR DESCRIPTION
Fix for: typo in docker-compose #183
Should be **--maxmemory-policy allkeys-lru** set instead of **--maxmemory-policy allkeys-lrulpine**.