### PR TITLE
Replace Redis with Valkey in docker-compose files

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -3,11 +3,11 @@
 
 services:
   redis:
-    image: redis:7-alpine
+    image: valkey/valkey:7-alpine
     # This is required to stay in RAM only.
-    command: redis-server --save "" --appendonly no
+    command: valkey-server --save "" --appendonly no
     # Set a size limit. See link below on how to customise.
-    # https://redis.io/docs/latest/operate/rs/databases/memory-performance/eviction-policy/
+    # https://valkey.io/docs/latest/operate/rs/databases/memory-performance/eviction-policy/
     # --maxmemory 1gb --maxmemory-policy allkeys-lrulpine
     # This prevents the creation of an anonymous volume.
     tmpfs:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,10 +1,10 @@
 services:
   redis:
-    image: redis:7-alpine
+    image: valkey/valkey:7-alpine
     # This is required to stay in RAM only.
-    command: redis-server --save "" --appendonly no
+    command: valkey-server --save "" --appendonly no
     # Set a size limit. See link below on how to customise.
-    # https://redis.io/docs/latest/operate/rs/databases/memory-performance/eviction-policy/
+    # https://valkey.io/docs/latest/operate/rs/databases/memory-performance/eviction-policy/
     # --maxmemory 1gb --maxmemory-policy allkeys-lrulpine
     # This prevents the creation of an anonymous volume.
     tmpfs:

--- a/examples/nginx/docker-compose.yaml
+++ b/examples/nginx/docker-compose.yaml
@@ -2,11 +2,11 @@ version: '3.8'
 
 services:
   redis:
-    image: redis:7-alpine
+    image: valkey/valkey:7-alpine
     # This is required to stay in RAM only.
-    command: redis-server --save "" --appendonly no
+    command: valkey-server --save "" --appendonly no
     # Set a size limit. See link below on how to customise.
-    # https://redis.io/docs/latest/operate/rs/databases/memory-performance/eviction-policy/
+    # https://valkey.io/docs/latest/operate/rs/databases/memory-performance/eviction-policy/
     # --maxmemory 1gb --maxmemory-policy allkeys-lrulpine
     # This prevents the creation of an anonymous volume.
     tmpfs:

--- a/examples/scratch/README.md
+++ b/examples/scratch/README.md
@@ -108,11 +108,11 @@ networks:
 
 services:
   redis:
-    image: redis:7-alpine
+    image: valkey/valkey:7-alpine
     # This is required to stay in RAM only.
-    command: redis-server --save "" --appendonly no
+    command: valkey-server --save "" --appendonly no
     # Set a size limit. See link below on how to customise.
-    # https://redis.io/docs/latest/operate/rs/databases/memory-performance/eviction-policy/
+    # https://valkey.io/docs/latest/operate/rs/databases/memory-performance/eviction-policy/
     # --maxmemory 1gb --maxmemory-policy allkeys-lrulpine
     # This prevents the creation of an anonymous volume.
     tmpfs:

--- a/examples/traefik/README.md
+++ b/examples/traefik/README.md
@@ -17,11 +17,11 @@ networks:
 
 services:
   redis:
-    image: redis:7-alpine
+    image: valkey/valkey:7-alpine
     # This is required to stay in RAM only.
-    command: redis-server --save "" --appendonly no
+    command: valkey-server --save "" --appendonly no
     # Set a size limit. See link below on how to customise.
-    # https://redis.io/docs/latest/operate/rs/databases/memory-performance/eviction-policy/
+    # https://valkey.io/docs/latest/operate/rs/databases/memory-performance/eviction-policy/
     # --maxmemory 1gb --maxmemory-policy allkeys-lrulpine
     # This prevents the creation of an anonymous volume.
     tmpfs:
@@ -61,11 +61,11 @@ services:
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
 
   redis:
-    image: redis:7-alpine
+    image: valkey/valkey:7-alpine
     # This is required to stay in RAM only.
-    command: redis-server --save "" --appendonly no
+    command: valkey-server --save "" --appendonly no
     # Set a size limit. See link below on how to customise.
-    # https://redis.io/docs/latest/operate/rs/databases/memory-performance/eviction-policy/
+    # https://valkey.io/docs/latest/operate/rs/databases/memory-performance/eviction-policy/
     # --maxmemory 1gb --maxmemory-policy allkeys-lrulpine
     # This prevents the creation of an anonymous volume.
     tmpfs:

--- a/packages/backend/src/store.rs
+++ b/packages/backend/src/store.rs
@@ -31,13 +31,13 @@ pub fn set(id: &String, note: &Note) -> Result<(), &'static str> {
     let serialized = serde_json::to_string(&note.clone()).unwrap();
     let mut conn = get_connection()?;
 
-    conn.set(id, serialized)
+    conn.set::<_, _, ()>(id, serialized)
         .map_err(|_| "Unable to set note in redis")?;
     match note.expiration {
         Some(e) => {
             let seconds = e - now();
-            conn.expire(id, seconds as i64)
-                .map_err(|_| "Unable to set expiration on notion")?
+            conn.expire::<_, ()>(id, seconds as i64)
+                .map_err(|_| "Unable to set expiration on note")?
         }
         None => {}
     };
@@ -58,6 +58,6 @@ pub fn get(id: &String) -> Result<Option<Note>, &'static str> {
 
 pub fn del(id: &String) -> Result<(), &'static str> {
     let mut conn = get_connection()?;
-    conn.del(id).map_err(|_| "Unable to delete note in redis")?;
+    conn.del::<_, ()>(id).map_err(|_| "Unable to delete note in redis")?;
     Ok(())
 }


### PR DESCRIPTION
Swap redis:7-alpine images to valkey/valkey:7-alpine across all docker-compose files and example READMEs. Keep service name as "redis" so that the default REDIS=redis://redis/ connection string still resolves correctly in Docker networking.

Also add turbofish type annotations to redis crate calls in store.rs for Rust 2024 never-type-fallback compatibility, and fix a typo ("notion" -> "note") in an error message.