### PR TITLE
basic file drag and drop support

### DIFF
--- a/packages/frontend/src/lib/ui/FileUpload.svelte
+++ b/packages/frontend/src/lib/ui/FileUpload.svelte
@@ -12,7 +12,7 @@
 	}
 
 	let { label = '', files = $bindable([]), ...rest }: Props = $props()
-	let hover_count = $state(0)
+	let hoverCount = $state(0)
 
 	async function fileToDTO(file: File): Promise<FileDTO> {
 		return {
@@ -35,7 +35,7 @@
 		e.preventDefault()
 		// https://developer.mozilla.org/en-US/docs/Web/API/DragEvent/dataTransfer
 		// "never null when dispatched by the browser"
-		hover_count = 0
+		hoverCount = 0
 		if (e.dataTransfer!.items.length != 0) {
 			const toAdd = await Promise.all(Array.from(e.dataTransfer!.files).map(fileToDTO))
 			files = [...files, ...toAdd]
@@ -68,10 +68,10 @@
 	<!-- svelte-ignore a11y_no_static_element_interactions -->
 	<div
 		class="box"
-		class:file-drag={hover_count !== 0}
+		class:file-drag={hoverCount !== 0}
 		ondrop={onDrop}
-		ondragenter={() => hover_count++}
-		ondragleave={() => hover_count--}
+		ondragenter={() => hoverCount++}
+		ondragleave={() => hoverCount--}
 	>
 		{#if files.length}
 			<div>

--- a/packages/frontend/src/lib/ui/FileUpload.svelte
+++ b/packages/frontend/src/lib/ui/FileUpload.svelte
@@ -12,6 +12,7 @@
 	}
 
 	let { label = '', files = $bindable([]), ...rest }: Props = $props()
+	let hover_count = $state(0)
 
 	async function fileToDTO(file: File): Promise<FileDTO> {
 		return {
@@ -30,18 +31,48 @@
 		}
 	}
 
+	async function onDrop(e: DragEvent) {
+		e.preventDefault()
+		// https://developer.mozilla.org/en-US/docs/Web/API/DragEvent/dataTransfer
+		// "never null when dispatched by the browser"
+		hover_count = 0
+		if (e.dataTransfer!.items.length != 0) {
+			const toAdd = await Promise.all(Array.from(e.dataTransfer!.files).map(fileToDTO))
+			files = [...files, ...toAdd]
+		}
+	}
+
 	function clear(e: Event) {
 		e.preventDefault()
 		files = []
 	}
 </script>
 
+<svelte:window
+	// cancels default browser behavior of downloading dragged file
+	ondrop={(e: DragEvent) => {
+		if ([...e.dataTransfer!.items].some((item) => item.kind === 'file')) {
+			e.preventDefault()
+		}
+	}}
+	ondragover={(e: DragEvent) => {
+		e.preventDefault()
+	}}
+/>
+
 <label>
 	<small>
 		{label}
 	</small>
 	<input {...rest} type="file" onchange={onInput} multiple />
-	<div class="box">
+	<!-- svelte-ignore a11y_no_static_element_interactions -->
+	<div
+		class="box"
+		class:file-drag={hover_count !== 0}
+		ondrop={onDrop}
+		ondragenter={() => hover_count++}
+		ondragleave={() => hover_count--}
+	>
 		{#if files.length}
 			<div>
 				<b>{$t('file_upload.selected_files')}</b>
@@ -76,6 +107,10 @@
 		justify-content: center;
 		align-items: center;
 		cursor: pointer;
+	}
+
+	.box.file-drag {
+		border-color: var(--ui-clr-primary);
 	}
 
 	.spacer {


### PR DESCRIPTION
this pr adds a _really basic_, but functioning, implementation of drag and drop support.

i worked on this during the period of free time that i currently have, and because of that the UX isn't really the best (but also firefox seemingly doesn't want [`dropEffect`](https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer/dropEffect) to work? maybe i'm just dumb and was misusing it, either way it's fine)

i intend on working on this slightly more in the future if i get the chance, but i would like the code to exist in the repository just on the off-chance that i never finish polishing it.